### PR TITLE
Make copyright year dynamic and swap Twitter icon for X logo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,8 @@ url: brian-ramos.com
 remote_theme: brirams/grayscale-theme
 
 social:
-    - title: twitter
-      url: https://twitter.com/bramos
+    - title: x
+      url: https://x.com/bramos
     - title: github
       url: https://github.com/brirams
     - title: linkedin

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,0 +1,15 @@
+    <!-- Contact Section -->
+    <section id="contact" class="container content-section text-center">
+        <div class="row">
+            <div class="col-lg-8 col-lg-offset-2">
+                <h2>Contact</h2>
+                <ul class="list-inline banner-social-buttons">
+                    {% for network in site.social %}
+                    <li>
+                        <a href="{{ network.url }}" class="btn btn-default btn-lg">{% if network.title == "x" %}{% include icons/x-logo.svg %}{% else %}<i class="fa fa-{{ network.title }} fa-fw"></i>{% endif %} <span class="network-name">{{ network.title }}</span></a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </section>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,9 @@
+    <!-- Footer -->
+    <footer>
+        <div class="container text-center">
+            <p>Copyright &copy; {{ site.footer }} <span id="copyright-year">{{ site.time | date: '%Y' }}</span></p>
+        </div>
+    </footer>
+    <script>
+        document.getElementById('copyright-year').textContent = new Date().getFullYear();
+    </script>

--- a/_includes/icons/x-logo.svg
+++ b/_includes/icons/x-logo.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" role="img" aria-label="X" style="width:1em;height:1em;vertical-align:-0.125em;fill:currentColor;"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>


### PR DESCRIPTION
## Summary
- Footer copyright year now renders client-side (`new Date().getFullYear()`) so it stays correct without needing a yearly redeploy — previously it was baked in at Jekyll build time via `site.time`, which only updates when the site is rebuilt.
- Social icon for X (formerly Twitter) is now an inline SVG of the X logo, sized/colored to inherit the existing button styling (`currentColor`, `fa-fw`-equivalent width) so it matches github/linkedin, which keep using Font Awesome. The theme's bundled Font Awesome 4.2 predates the X logo, so there's no font-icon equivalent.
- `_config.yml` social entry renamed `twitter` → `x`, URL updated to `https://x.com/bramos`.

All changes are local `_includes` overrides (`footer.html`, `contact.html`, `icons/x-logo.svg`), matching the pattern already used in this repo for `nav.html`/`head.html`/`about.html`/`js.html`. The shared `brirams/grayscale-theme` repo is untouched.

## Test plan
- [x] Built the site locally with the real remote theme (via a pinned Ruby/Jekyll Docker container) and confirmed the rendered HTML shows the SVG X icon in the contact section and `<span id="copyright-year">` populated in the footer.
- [ ] Visually confirm in a browser after merge/deploy that the X icon sizing/color matches the github/linkedin icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)